### PR TITLE
Make legal code optional for search

### DIFF
--- a/cli/client.py
+++ b/cli/client.py
@@ -123,8 +123,8 @@ class LegalMCPClient:
 
     def search_texts(
         self,
-        code: str,
         query: str,
+        code: Optional[str] = None,
         limit: int = 10,
         cutoff: float = 0.7
     ) -> Dict[str, Any]:
@@ -132,8 +132,9 @@ class LegalMCPClient:
         Perform semantic search on legal texts
 
         Args:
-            code: Legal code identifier (e.g., 'bgb', 'stgb')
             query: Search query text
+            code: Optional legal code identifier (e.g., 'bgb', 'stgb').
+                  If not provided, searches all codes.
             limit: Maximum number of results (default: 10)
             cutoff: Similarity cutoff threshold (default: 0.7)
 
@@ -143,14 +144,19 @@ class LegalMCPClient:
         Raises:
             httpx.HTTPStatusError: If the API returns an error status
         """
-        params = {
+        params: Dict[str, Any] = {
             "q": query,
             "limit": limit,
             "cutoff": cutoff
         }
 
+        # Add code to params if provided
+        if code is not None:
+            params["code"] = code
+
+        # Use the global search endpoint which accepts optional code parameter
         response = self.client.get(
-            f"/legal-texts/gesetze-im-internet/{code}/search",
+            "/legal-texts/search",
             params=params
         )
         response.raise_for_status()

--- a/store/app/repository.py
+++ b/store/app/repository.py
@@ -148,7 +148,7 @@ class LegalTextRepository:
     async def semantic_search(
         self,
         query_embedding: Sequence[float],
-        code: str,
+        code: Optional[str] = None,
         limit: int = 10,
         cutoff: Optional[float] = None,
     ) -> List[Tuple[LegalTextDB, float]]:
@@ -156,11 +156,11 @@ class LegalTextRepository:
         Perform semantic similarity search using vector embeddings
 
         Uses cosine distance to find the most similar legal texts to the query.
-        Results are filtered by code and ordered by similarity (closest first).
+        Results are optionally filtered by code and ordered by similarity (closest first).
 
         Args:
             query_embedding: The embedding vector of the search query
-            code: The legal code to filter by (required)
+            code: Optional legal code to filter by. If None, searches all codes.
             limit: Maximum number of results to return (default: 10)
             cutoff: Optional maximum cosine distance threshold (default: None)
                     Only return results with distance <= cutoff
@@ -185,10 +185,13 @@ class LegalTextRepository:
                 LegalTextDB,
                 distance_expr.label("distance"),
             )
-            .filter(LegalTextDB.code == code)
             .order_by("distance")
             .limit(limit)
         )
+
+        # Filter by code only if specified
+        if code is not None:
+            query = query.filter(LegalTextDB.code == code)
 
         # Apply cutoff filter if specified
         if cutoff is not None:


### PR DESCRIPTION
Make the legal code optional for content search to allow searching across all database entries when no specific code is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-f80a3118-02e5-428b-aa6c-76fe8b267755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f80a3118-02e5-428b-aa6c-76fe8b267755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

