### PR TITLE
Clarify ollama model requirement in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ A comprehensive system for searching and analyzing German legal texts using vect
 - Ollama (local or remote endpoint for embeddings)
 - Git
 
+> ⚠️ **Important: Required Ollama Model**
+>
+> This project uses a **hardcoded embedding model**: `ryanshillington/Qwen3-Embedding-4B:latest`
+>
+> You must pull this specific model before importing legal texts:
+> ```bash
+> ollama pull ryanshillington/Qwen3-Embedding-4B:latest
+> ```
+>
+> The model produces 2560-dimensional vectors, and changing the model would require database schema modifications and re-importing all legal texts.
+
 ### 1. Clone and Setup
 
 ```bash
@@ -329,6 +340,8 @@ OLLAMA_AUTH_TOKEN=your-auth-token-here
 # PostgreSQL Configuration
 POSTGRES_HOST=postgres  # Use 'postgres' in Docker, 'localhost' for local dev
 ```
+
+> **Note:** While the Ollama endpoint URL is configurable, the embedding model (`ryanshillington/Qwen3-Embedding-4B:latest`) is currently hardcoded in `store/app/embedding.py`. Ensure your Ollama instance has this model available.
 
 ### Additional Configuration (set in docker-compose.yml)
 


### PR DESCRIPTION
Clarify the required Ollama embedding model in the README for self-hosters.

The embedding model `ryanshillington/Qwen3-Embedding-4B:latest` is currently hardcoded in `store/app/embedding.py`. This PR adds a prominent warning and a note to the README to inform self-hosters about this specific model requirement, including the `ollama pull` command, and explains that changing the model would require database schema modifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-be05bfb2-8e11-49eb-a5f4-d2f02b00de4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-be05bfb2-8e11-49eb-a5f4-d2f02b00de4f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the hardcoded Ollama embedding model requirement in the README, adding pull instructions and noting schema implications and configurability limits.
> 
> - **Documentation (README)**
>   - Add prominent warning about required embedding model `ryanshillington/Qwen3-Embedding-4B:latest` with `ollama pull` command and note that it produces 2560-dim vectors (schema impact if changed).
>   - Clarify that `OLLAMA_BASE_URL` is configurable but the model is hardcoded in `store/app/embedding.py` and must be available on the Ollama instance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59d07e00647561411eae7cd7934145d8dca37e3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->